### PR TITLE
Make the API a bit more convenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Or install it yourself as:
   p second_try_lock_info
 ```
 
+There's also a block version that automatically unlocks the lock:
+
+```ruby
+lock_manager.lock("resource_key", 2000) do |locked|
+  if locked
+    # critical code
+  else
+    # error handling
+  end
+end
+```
+
 ## Run tests
 
 Make sure you have at least 3 redis instances `redis-server --port 777[7-9]`

--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'redis', '~> 3', '>= 3.0.5'
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -33,6 +33,53 @@ RSpec.describe Redlock::Client do
         expect(lock_info).to eql(false)
       end
     end
+
+    describe 'block syntax' do
+      context 'when lock is available' do
+        it 'locks' do
+          lock_manager.lock(resource_key, ttl) do |_|
+            expect(resource_key).to_not be_lockable(lock_manager, ttl)
+          end
+        end
+
+        it 'passes lock information as block argument' do
+          lock_manager.lock(resource_key, ttl) do |lock_info|
+            expect(lock_info).to be_lock_info_for(resource_key)
+          end
+        end
+
+        it 'returns true' do
+          rv = lock_manager.lock(resource_key, ttl) {}
+          expect(rv).to eql(true)
+        end
+
+        it 'automatically unlocks' do
+          lock_manager.lock(resource_key, ttl) {}
+          expect(resource_key).to be_lockable(lock_manager, ttl)
+        end
+
+        it 'automatically unlocks when block raises exception' do
+          lock_manager.lock(resource_key, ttl) { fail } rescue nil
+          expect(resource_key).to be_lockable(lock_manager, ttl)
+        end
+      end
+
+      context 'when lock is not available' do
+        before { @another_lock_info = lock_manager.lock(resource_key, ttl) }
+        after { lock_manager.unlock(@another_lock_info) }
+
+        it 'passes false as block argument' do
+          lock_manager.lock(resource_key, ttl) do |lock_info|
+            expect(lock_info).to eql(false)
+          end
+        end
+
+        it 'returns false' do
+          rv = lock_manager.lock(resource_key, ttl) {}
+          expect(rv).to eql(false)
+        end
+      end
+    end
   end
 
   describe 'unlock' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,25 +1,49 @@
 require 'spec_helper'
+require 'securerandom'
 
 RSpec.describe Redlock::Client do
   let(:lock_manager) { Redlock::Client.new([ "redis://127.0.0.1:7777", "redis://127.0.0.1:7778", "redis://127.0.0.1:7779" ]) }
-  let(:resource_key) { "foo" }
+  let(:resource_key) { SecureRandom.hex(3)  }
   let(:ttl) { 1000 }
 
-  it 'locks' do
-    first_try_lock_info = lock_manager.lock(resource_key, ttl)
-    second_try_lock_info = lock_manager.lock(resource_key, ttl)
+  describe 'lock' do
+    context 'when lock is available' do
+      after(:each) { lock_manager.unlock(@lock_info) if @lock_info }
 
-    expect(first_try_lock_info[:resource]).to eq("foo")
-    expect(second_try_lock_info).to be_falsy
+      it 'locks' do
+        @lock_info = lock_manager.lock(resource_key, ttl)
 
-    lock_manager.unlock(first_try_lock_info)
+        expect(resource_key).to_not be_lockable(lock_manager, ttl)
+      end
+
+      it 'returns lock information' do
+        @lock_info = lock_manager.lock(resource_key, ttl)
+
+        expect(@lock_info).to be_lock_info_for(resource_key)
+      end
+    end
+
+    context 'when lock is not available' do
+      before { @another_lock_info = lock_manager.lock(resource_key, ttl) }
+      after { lock_manager.unlock(@another_lock_info) }
+
+      it 'returns false' do
+        lock_info = lock_manager.lock(resource_key, ttl)
+
+        expect(lock_info).to eql(false)
+      end
+    end
   end
 
-  it 'unlocks' do
-    lock_info = lock_manager.lock(resource_key, ttl)
-    lock_manager.unlock(lock_info)
-    another_lock_info = lock_manager.lock(resource_key, ttl)
+  describe 'unlock' do
+    before { @lock_info = lock_manager.lock(resource_key, ttl) }
 
-    expect(another_lock_info[:resource]).to eq("foo")
+    it 'unlocks' do
+      expect(resource_key).to_not be_lockable(lock_manager, ttl)
+
+      lock_manager.unlock(@lock_info)
+
+      expect(resource_key).to be_lockable(lock_manager, ttl)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,40 @@
-# coding: utf-8
-# $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'redlock'
+
+LOCK_INFO_KEYS = %i{validity resource value}
+
+RSpec::Matchers.define :be_lock_info_for do |resource|
+  def correct_type?(actual)
+    actual.is_a?(Hash)
+  end
+
+  def correct_layout?(actual)
+    ((LOCK_INFO_KEYS | actual.keys) - (LOCK_INFO_KEYS & actual.keys)).empty?
+  end
+
+  def correct_resource?(actual, resource)
+    actual[:resource] == resource
+  end
+
+  match do |actual|
+    correct_type?(actual) && correct_layout?(actual) && correct_resource?(actual, resource)
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} would be lock information for #{expected}"
+  end
+end
+
+RSpec::Matchers.define :be_lockable do |lock_manager, ttl|
+  match do |resource_key|
+    begin
+      lock_info = lock_manager.lock(resource_key, ttl)
+      lock_info != false
+    ensure
+      lock_manager.unlock(lock_info) if lock_info
+    end
+  end
+
+  failure_message do |resource_key|
+    "expected that #{resource_key} would be lockable"
+  end
+end


### PR DESCRIPTION
Hey Leandro,

see patches. We are using the Redlock algorithm in our software already, albeit only for single server environments. Would like to switch to your gem, so I thought it'll be nice to make the API a bit more convenient. The client does not care much about `lock_info`.