### PR TITLE
Permits initialization with existing Redis objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redlock (0.0.4)
+    redlock (0.1.0)
       redis (~> 3, >= 3.0.5)
 
 GEM

--- a/lib/redlock/version.rb
+++ b/lib/redlock/version.rb
@@ -1,3 +1,3 @@
 module Redlock
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe Redlock::Client do
   let(:resource_key) { SecureRandom.hex(3)  }
   let(:ttl) { 1000 }
 
+  describe 'initialize' do
+    it 'accepts both redis URLs and Redis objects' do
+      servers = [ 'redis://localhost:6379', Redis.new(:url => 'redis://someotherhost:6379') ]
+      redlock = Redlock::Client.new(servers)
+
+      redlock_servers = redlock.instance_variable_get(:@servers)
+
+      expect(redlock_servers.one? { |s| s.redis.client.host == 'localhost' })
+      expect(redlock_servers.one? { |s| s.redis.client.port == 'someotherhost' })
+    end
+  end
+
   describe 'lock' do
     context 'when lock is available' do
       after(:each) { lock_manager.unlock(@lock_info) if @lock_info }


### PR DESCRIPTION
This allows the Redlock gem to seamlessly work with redis sentinel, which is supported in redis 3.2+.

It also allows clients to set any other arbitrary options on the Redis connection, e.g. password, driver, and more

Bumped version to 0.1.0 per semantic versioning guidelines since functionality was added in a backwards-compatible manner.

Also changed the set command sent to Redis::Client to use 'NX' and 'PX' instead of `:nx` and `:px`. This matches the behavior of `Redis#set` which parses `{:nx => true, :px => 123}` into `['NX', 'PX', 123]`. This was needed in order for the redlock gem to work with the fakeredis gem (an in-memory fake redis server commonly used in CI/Test environments).