### PR TITLE
Redis::Client#call to Redis#set and Redis#eval

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -77,11 +77,11 @@ module Redlock
       end
 
       def lock(resource, val, ttl)
-        @redis.client.call([:set, resource, val, 'NX', 'PX', ttl])
+        @redis.set(resource, val, nx: true, px: ttl)
       end
 
       def unlock(resource, val)
-        @redis.client.call([:eval, UNLOCK_SCRIPT, 1, resource, val])
+        @redis.eval(UNLOCK_SCRIPT, [resource], [val])
       rescue
         # Nothing to do, unlocking is just a best-effort attempt.
       end

--- a/lib/redlock/version.rb
+++ b/lib/redlock/version.rb
@@ -1,3 +1,3 @@
 module Redlock
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Using `Redis::Client#call` directly is circumventing the Redis gem's use of `MonitorMixin` within the `Redis` class to prevent multiple concurrent calls to `Redis::Client#call`. This could have undesirable effects on redlock usage in true multi-threaded interpreters such as JRuby.

It also makes the `Redlock::Client#lock` method work with fakeredis.

Initially reported via #10 