### PR TITLE
Preload UNLOCK_SCRIPT on Redis servers.

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -74,6 +74,8 @@ module Redlock
         else
           @redis  = Redis.new(connection)
         end
+
+        @unlock_script_sha = @redis.script(:load, UNLOCK_SCRIPT)
       end
 
       def lock(resource, val, ttl)
@@ -81,7 +83,7 @@ module Redlock
       end
 
       def unlock(resource, val)
-        @redis.eval(UNLOCK_SCRIPT, [resource], [val])
+        @redis.evalsha(@unlock_script_sha, keys: [resource], argv: [val])
       rescue
         # Nothing to do, unlocking is just a best-effort attempt.
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Redlock::Client do
 
   describe 'initialize' do
     it 'accepts both redis URLs and Redis objects' do
-      servers = [ 'redis://localhost:6379', Redis.new(url: 'redis://someotherhost:6379') ]
+      servers = [ 'redis://localhost:6379', Redis.new(url: 'redis://127.0.0.1:6379') ]
       redlock = Redlock::Client.new(servers)
 
       redlock_servers = redlock.instance_variable_get(:@servers).map do |s|
         s.instance_variable_get(:@redis).client.host
       end
 
-      expect(redlock_servers).to match_array(%w{ localhost someotherhost })
+      expect(redlock_servers).to match_array(%w{ localhost 127.0.0.1 })
     end
   end
 


### PR DESCRIPTION
Inspired by aceofsales/redlock-rb@1f554c855935fab91edba534e0957084694aa243

Had to change the 'Redlock::Client accepts both redis URLs and Redis
objects' test case due to the initial communication with the Redis
server.