### PR TITLE
[Refactor] Move testing code into loadable module

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -30,27 +30,13 @@ module Redlock
       @retry_delay = options[:retry_delay] || DEFAULT_RETRY_DELAY
     end
 
-    def testing=(mode)
-      @testing_mode = mode
-    end
-
     # Locks a resource for a given time.
     # Params:
     # +resource+:: the resource (or key) string to be locked.
     # +ttl+:: The time-to-live in ms for the lock.
     # +block+:: an optional block that automatically unlocks the lock.
     def lock(resource, ttl, &block)
-      if @testing_mode == :bypass
-        lock_info = {
-          validity: ttl,
-          resource: resource,
-          value: SecureRandom.uuid
-        }
-      elsif @testing_mode == :fail
-        lock_info = false
-      else
-        lock_info = try_lock_instances(resource, ttl)
-      end
+      lock_info = try_lock_instances(resource, ttl)
 
       if block_given?
         begin
@@ -68,8 +54,6 @@ module Redlock
     # Params:
     # +lock_info+:: the lock that has been acquired when you locked the resource.
     def unlock(lock_info)
-      return if @testing_mode == :bypass
-
       @servers.each { |s| s.unlock(lock_info[:resource], lock_info[:value]) }
     end
 

--- a/lib/redlock/testing.rb
+++ b/lib/redlock/testing.rb
@@ -1,0 +1,27 @@
+module Redlock
+  class Client
+    attr_writer :testing_mode
+
+    alias_method :try_lock_instances_without_testing, :try_lock_instances
+
+    def try_lock_instances(resource, ttl)
+      if @testing_mode == :bypass
+        {
+          validity: ttl,
+          resource: resource,
+          value: SecureRandom.uuid
+        }
+      elsif @testing_mode == :fail
+        false
+      else
+        try_lock_instances_without_testing resource, ttl
+      end
+    end
+
+    alias_method :unlock_without_testing, :unlock
+
+    def unlock(lock_info)
+      unlock_without_testing lock_info unless @testing_mode == :bypass
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -94,30 +94,6 @@ RSpec.describe Redlock::Client do
         end
       end
     end
-
-    context 'when testing with bypass mode' do
-      before { lock_manager.testing = :bypass }
-      after { lock_manager.testing = nil }
-
-      it 'bypasses the redis servers' do
-        expect(lock_manager).to_not receive(:try_lock_instances)
-        lock_manager.lock(resource_key, ttl) do |lock_info|
-          expect(lock_info).to be_lock_info_for(resource_key)
-        end
-      end
-    end
-
-    context 'when testing with fail mode' do
-      before { lock_manager.testing = :fail }
-      after { lock_manager.testing = nil }
-
-      it 'fails' do
-        expect(lock_manager).to_not receive(:try_lock_instances)
-        lock_manager.lock(resource_key, ttl) do |lock_info|
-          expect(lock_info).to eql(false)
-        end
-      end
-    end
   end
 
   describe 'unlock' do

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'securerandom'
+
+require 'redlock/testing'
+
+RSpec.describe Redlock::Client do
+  let(:lock_manager) { Redlock::Client.new }
+  let(:resource_key) { SecureRandom.hex(3)  }
+  let(:ttl) { 1000 }
+
+  describe '(testing mode)' do
+    describe 'try_lock_instances' do
+      context 'when testing with bypass mode' do
+        before { lock_manager.testing_mode = :bypass }
+
+        it 'bypasses the redis servers' do
+          expect(lock_manager).to_not receive(:try_lock_instances_without_testing)
+          lock_manager.lock(resource_key, ttl) do |lock_info|
+            expect(lock_info).to be_lock_info_for(resource_key)
+          end
+        end
+      end
+
+      context 'when testing with fail mode' do
+        before { lock_manager.testing_mode = :fail }
+
+        it 'fails' do
+          expect(lock_manager).to_not receive(:try_lock_instances_without_testing)
+          lock_manager.lock(resource_key, ttl) do |lock_info|
+            expect(lock_info).to eql(false)
+          end
+        end
+      end
+
+      context 'when testing is disabled' do
+        before { lock_manager.testing_mode = nil }
+
+        it 'works as usual' do
+          expect(lock_manager).to receive(:try_lock_instances_without_testing)
+          lock_manager.lock(resource_key, ttl) { |lock_info| }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I felt the urge to move the testing mode introduced by @ryansch to a different file to avoid evaluating the `@testing_mode` conditionals in production code.

@ryansch For testing you'd have to manually require `redlock/testing` now. Also, I renamed `Redlock::Client.testing=()` to `Redlock::Client.testing_mode=()` using an `attr_writer`. Are you ok with these changes?