### PR TITLE
use extend to implement heartbeat

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -142,11 +142,12 @@ module Redlock
       end
 
       validity = ttl - time_elapsed - drift(ttl)
+      used_value = extend ? extend[:value] : value
 
       if locked >= @quorum && validity >= 0
-        { validity: validity, resource: resource, value: value }
+        { validity: validity, resource: resource, value: used_value }
       else
-        @servers.each { |s| s.unlock(resource, value) }
+        @servers.each { |s| s.unlock(resource, used_value) }
         false
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Redlock::Client do
         my_lock_info = lock_manager.lock(resource_key, ttl)
         @lock_info = lock_manager.lock(resource_key, ttl, extend: my_lock_info)
         expect(@lock_info).to be_lock_info_for(resource_key)
+        expect(@lock_info[:value]).to eq(my_lock_info[:value])
+      end
+
+      it "sets the given value when trying to extend a non-existent lock" do
+        @lock_info = lock_manager.lock(resource_key, ttl, extend: {value: 'hello world'})
+        expect(@lock_info).to be_lock_info_for(resource_key)
+        expect(@lock_info[:value]).to eq('hello world') # really we should test what's in redis
       end
 
       it "doesn't extend lock by default" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Redlock::Client do
 
         expect(@lock_info).to be_lock_info_for(resource_key)
       end
+
+      it 'can extend its own lock' do
+        my_lock_info = lock_manager.lock(resource_key, ttl)
+        @lock_info = lock_manager.lock(resource_key, ttl, extend: my_lock_info)
+        expect(@lock_info).to be_lock_info_for(resource_key)
+      end
+
+      it "doesn't extend lock by default" do
+        @lock_info = lock_manager.lock(resource_key, ttl)
+        second_attempt = lock_manager.lock(resource_key, ttl)
+        expect(second_attempt).to eq(false)
+      end
     end
 
     context 'when lock is not available' do
@@ -44,6 +56,12 @@ RSpec.describe Redlock::Client do
       it 'returns false' do
         lock_info = lock_manager.lock(resource_key, ttl)
 
+        expect(lock_info).to eql(false)
+      end
+
+      it "can't extend somebody else's lock" do
+        yet_another_lock_info = @another_lock_info.merge value: 'gibberish'
+        lock_info = lock_manager.lock(resource_key, ttl, extend: yet_another_lock_info)
         expect(lock_info).to eql(false)
       end
     end


### PR DESCRIPTION
(this PR depends on https://github.com/leandromoreira/redlock-rb/pull/20)

here's a tested example of implementing a heartbeat using extend

```ruby
lock_manager.lock(resource, ttl) do
  # this takes out a lock every second until the ttl is used up (plus a remainder at the end)
  # if this process is killed, the lock will expire quickly
end
```

it looks complicated, but that's a good reason that the library should implement it (i think?)

cc @antirez @maltoe @leandromoreira 