### PR TITLE
Add Client#with_lock method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ lock_manager.lock("resource_key", 2000) do |locked|
 end
 ```
 
+There's also a bang version that only executes the block if the lock is successfully acquired, returning the block's value as a result, or raising an exception otherwise:
+
+```ruby
+begin
+  block_result = lock_manager.lock!("resource_key", 2000) do
+    # critical code
+  end
+rescue Redlock::LockException
+  # error handling
+end
+```
+
 ## Run tests
 
 Make sure you have at least 1 redis instances up.

--- a/lib/redlock.rb
+++ b/lib/redlock.rb
@@ -2,4 +2,6 @@ require 'redlock/version'
 
 module Redlock
   autoload :Client, 'redlock/client'
+
+  class LockException < StandardError; end
 end

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -57,6 +57,23 @@ module Redlock
       @servers.each { |s| s.unlock(lock_info[:resource], lock_info[:value]) }
     end
 
+    # Locks a resource, executing the received block only after successfully acquiring the lock,
+    # and returning its return value as a result.
+    # Params:
+    # +resource+:: the resource (or key) string to be locked.
+    # +ttl+:: the time-to-live in ms for the lock.
+    # +block+:: block to be executed after successful lock acquisition.
+    def with_lock(resource, ttl,  &block)
+      raise "No block passed" unless block
+
+      rv = nil
+      lock(resource, ttl) do |lock_info|
+        raise LockException, "Could not acquire lock #{resource}" unless lock_info
+        rv = block.call
+      end
+      rv
+    end
+
     private
 
     class RedisInstance

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -64,13 +64,13 @@ module Redlock
     # +resource+:: the resource (or key) string to be locked.
     # +ttl+:: the time-to-live in ms for the lock.
     # +block+:: block to be executed after successful lock acquisition.
-    def with_lock(resource, ttl,  &block)
-      raise "No block passed" unless block
+    def with_lock(resource, ttl)
+      fail "No block passed" unless block_given?
 
       rv = nil
       lock(resource, ttl) do |lock_info|
         raise LockException, "Could not acquire lock #{resource}" unless lock_info
-        rv = block.call
+        rv = yield
       end
       rv
     end

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -34,7 +34,8 @@ module Redlock
     # Params:
     # +resource+:: the resource (or key) string to be locked.
     # +ttl+:: The time-to-live in ms for the lock.
-    # +block+:: an optional block that automatically unlocks the lock.
+    # +block+:: an optional block to be executed; after its execution, the lock (if successfully
+    # acquired) is automatically unlocked.
     def lock(resource, ttl, &block)
       lock_info = try_lock_instances(resource, ttl)
 

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -64,7 +64,7 @@ module Redlock
     # +resource+:: the resource (or key) string to be locked.
     # +ttl+:: the time-to-live in ms for the lock.
     # +block+:: block to be executed after successful lock acquisition.
-    def with_lock(resource, ttl)
+    def lock!(resource, ttl)
       fail "No block passed" unless block_given?
 
       rv = nil

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -108,28 +108,28 @@ RSpec.describe Redlock::Client do
     end
   end
 
-  describe 'with_lock' do
+  describe 'lock!' do
     context 'when lock is available' do
       it 'locks' do
-        lock_manager.with_lock(resource_key, ttl) do |_|
+        lock_manager.lock!(resource_key, ttl) do |_|
           expect(resource_key).to_not be_lockable(lock_manager, ttl)
         end
       end
 
       it "returns the received block's return value" do
-        rv = lock_manager.with_lock(resource_key, ttl) do
+        rv = lock_manager.lock!(resource_key, ttl) do
           :success
         end
         expect(rv).to eql(:success)
       end
 
       it 'automatically unlocks' do
-        lock_manager.with_lock(resource_key, ttl) {}
+        lock_manager.lock!(resource_key, ttl) {}
         expect(resource_key).to be_lockable(lock_manager, ttl)
       end
 
       it 'automatically unlocks when block raises exception' do
-        lock_manager.with_lock(resource_key, ttl) { fail } rescue nil
+        lock_manager.lock!(resource_key, ttl) { fail } rescue nil
         expect(resource_key).to be_lockable(lock_manager, ttl)
       end
     end
@@ -139,14 +139,14 @@ RSpec.describe Redlock::Client do
       after { lock_manager.unlock(@another_lock_info) }
 
       it 'raises a LockException' do
-        expect { lock_manager.with_lock(resource_key, ttl) {} }.to raise_error(Redlock::LockException)
+        expect { lock_manager.lock!(resource_key, ttl) {} }.to raise_error(Redlock::LockException)
       end
 
       it 'does not execute the block' do
         block_ran = false
 
         begin
-          lock_manager.with_lock(resource_key, ttl) do
+          lock_manager.lock!(resource_key, ttl) do
             block_ran = true
           end
         rescue


### PR DESCRIPTION
`with_lock` is a simple wrapper around `lock` that only executes the received
block if lock acquisition was successful (e.g. client code doesn't need to
test for successful lock acquisition), and that returns the block's return
value as result.

When lock acquisition fails, `with_lock` raises a `Redlock::LockException`, which
can be used by client code to handle failure.