### PR TITLE
Add support for MockRedis in testing mode

### DIFF
--- a/lib/redlock/testing.rb
+++ b/lib/redlock/testing.rb
@@ -32,6 +32,8 @@ module Redlock
       rescue Redis::CommandError
         # FakeRedis doesn't have #script, but doesn't need it either.
         raise unless defined?(::FakeRedis)
+      rescue NoMethodError
+        raise unless defined?(::MockRedis)
       end
     end
   end


### PR DESCRIPTION
Hey,

Very similar problem to the one with [FakeRedis](https://github.com/leandromoreira/redlock-rb/pull/22).
It does not support `script`.
Hope this does not look too hacky. :smile: 

Thanks