### PR TITLE
Protect from TTL units regressions (see #44)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,3 +41,11 @@ RSpec::Matchers.define :be_lockable do |lock_manager, ttl|
     "expected that #{resource_key} would be lockable"
   end
 end
+
+RSpec.configure do |c|
+  # NOTE: this protects against erroneous "focus: true" commits
+  unless ENV['CI'] == 'true'
+    c.filter_run focus: true
+    c.run_all_when_everything_filtered = true
+  end
+end


### PR DESCRIPTION
In this PR:
- one spec to enforce millisecond use on the initial lock creation
- one spec to enforce millisecond use when extending a lock (see #44)
- one spec to assert that subsequent calls to extend a lock will reset the TTL rather than add to it

I will work later on another PR (or add to this one if it's not yet merged) to tweak the README accordingly.
