### PR TITLE
Add retry_jitter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ rescue Redlock::LockError
 end
 ```
 
+It's possible to customize the retry logic providing the following options:
+
+```ruby
+  lock_manager = Redlock::Client.new(
+                  servers, {
+                  retry_count:   3,
+                  retry_delay:   200, # milliseconds
+                  retry_jitter:  50,  # milliseconds
+                  retry_timeout: 0.1  # seconds
+                 })
+```
+
+For more information you can check [documentation](https://github.com/leandromoreira/redlock-rb/blob/master/lib/redlock/client.rb#L13-L20)
+
 
 ## Run tests
 


### PR DESCRIPTION
This is a suggestion for an improvement based on the needs we're facing in my current company.

As the current implementation use a random value based on the default delay or the provided `retry_delay` option some delays can be minimum. If we increase the value we can have huge delays and sleeps which it's something that we don't like either.

So what about to be able to set a default delay amount and on top of that add a random amount of time, both configurable. Well, that's what this PR implements.

Does it make sense? Any feedback is welcome.