### PR TITLE
Support 'redis-rb' version 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     redlock (0.2.0)
-      redis (~> 3, >= 3.0.0)
+      redis (>= 3.0.0, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -17,7 +17,7 @@ GEM
     docile (1.1.5)
     json (2.0.3)
     rake (11.3.0)
-    redis (3.3.3)
+    redis (4.0.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -51,4 +51,4 @@ DEPENDENCIES
   rspec (~> 3, >= 3.0.0)
 
 BUNDLED WITH
-   1.12.5
+   1.16.0

--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'redis', '~> 3', '>= 3.0.0'
+  spec.add_dependency 'redis', '>= 3.0.0', '< 5.0'
 
   spec.add_development_dependency "coveralls", "~> 0.8.13"
   spec.add_development_dependency 'rake', '~> 11.1', '>= 11.1.2'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Redlock::Client do
       redlock = Redlock::Client.new(servers)
 
       redlock_servers = redlock.instance_variable_get(:@servers).map do |s|
-        s.instance_variable_get(:@redis).client.host
+        s.instance_variable_get(:@redis).connection[:host]
       end
 
       expect(redlock_servers).to match_array([redis1_host, redis2_host])


### PR DESCRIPTION
This updates the version constraint of the 'redis-rb' dependency to include version 4. I have reviewed the [change log](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md), and none of the changes seem to affect the library itself. Only a single spec had to be updated, because since the added support for the `CLIENT` command, it is not recommended to use the lower-level client directly anymore (it can still be accessed via `Redis#_client`). Hence, I have updated the spec to use the newly added `Redis#connection` instead, which exposes the necessary connection information.