### PR TITLE
Fix issue 60 rescue connection error

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -112,6 +112,8 @@ module Redlock
         recover_from_script_flush do
           @redis.evalsha @lock_script_sha, keys: [resource], argv: [val, ttl, allow_new_lock]
         end
+      rescue Redis::CannotConnectError
+        false
       end
 
       def unlock(resource, val)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Redlock::Client do
 
   describe 'initialize' do
     it 'accepts both redis URLs and Redis objects' do
-      print redis1_host
       servers = [ "redis://#{redis1_host}:#{redis1_port}", Redis.new(url: "redis://#{redis2_host}:#{redis2_port}") ]
       redlock = Redlock::Client.new(servers)
 


### PR DESCRIPTION
Hey @leandromoreira 

I took the time to address issue #60. IMO the algorithm should be able to cope with netsplits and the like, choosing CP over AP with the quorum. Rescued the `Redis::CannotConnectError` in the `RedisInstance.lock` method.

Questions/TODO:

* Not sure if `Redis::CannotConnectError` is all we should handle, or if other situations (connection dies halfway through, etc.) create other errors.
* The "recovery" test in the specs does not really cover a true broken-connection `Redis` object, and I didn't check whether it actually is able to recover from `CannotConnectError` like this.
* Generally the test is half-assed. Didn't have three redis instances available to really test it.

Suggestions / contributions welcome :-)

malte