### PR TITLE
Don't load scripts on client initialization

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -118,8 +118,6 @@ module Redlock
         else
           @redis = Redis.new(connection)
         end
-
-        load_scripts
       end
 
       def lock(resource, val, ttl, allow_new_lock)


### PR DESCRIPTION
The `recover_from_script_flush` block will load scripts if they're not
loaded yet, so there's no need to load the scripts for every new client
instantiation. The loads ought to be redundant more often than not.