### PR TITLE
Add locked? and owner? methods to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ The above code will also acquire the lock if the previous lock has expired and t
 lock_manager.lock("resource key", 3000, extend: lock_info, extend_life: true)
 ```
 
+### Checking if a lock exists
+
+If you intend to try and acquire a lock always use [`#lock`](#acquiring-a-lock)
+
+```ruby
+lock_manager = Redlock::Client.new([ "redis://127.0.0.1:7777", "redis://127.0.0.1:7778", "redis://127.0.0.1:7779" ])
+
+lock_manager.locked?("resource_key")
+# => false
+
+lock_info = lock_manager.lock("resource_key", 2000)
+# => {validty: 1987, resource: "resource_key", value: "generated_uuid4"}
+
+lock_manager.locked?("resource_key")
+# => true
+```
+
+Note: The indication given here does not mean a client is currently holding the lock. It might indicate that a client is holding it, or was holding it, or is currently trying to acquire it. It does not even tell you that it is currently possible to acquire the lock by the client asking `locked?`
+
 ## Redis client configuration
 
 `Redlock::Client` expects URLs or Redis objects on initialization. Redis objects should be used for configuring the connection in more detail, i.e. setting username and password.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ lock_manager.locked?("resource_key")
 
 Note: The indication given here does not mean a client is currently holding the lock. It might indicate that a client is holding it, or was holding it, or is currently trying to acquire it. It does not even tell you that it is currently possible to acquire the lock by the client asking `locked?`
 
+### Validating lock ownership
+
+```ruby
+lock_manager = Redlock::Client.new([ "redis://127.0.0.1:7777", "redis://127.0.0.1:7778", "redis://127.0.0.1:7779" ])
+lock_info = lock_manager.lock("resource_key", 2000)
+
+lock_manager.owner?(lock_info)
+# => true
+
+sleep 3
+
+lock_manager.owner?(lock_info)
+# => false
+```
+
 ## Redis client configuration
 
 `Redlock::Client` expects URLs or Redis objects on initialization. Redis objects should be used for configuring the connection in more detail, i.e. setting username and password.

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -99,6 +99,13 @@ module Redlock
       @servers.any? { |s| s.lock_exists?(resource)}
     end
 
+    # Checks is we own the lock for a resource.
+    # Params:
+    # +lock_info+:: The lock that has been acquired when you locked the resource.
+    def owner?(lock_info)
+      @servers.any? { |s| s.lock_exists?(lock_info[:resource], lock_info[:value])}
+    end
+
     private
 
     class RedisInstance

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -92,6 +92,13 @@ module Redlock
       end
     end
 
+    # Checks if a lock for resource exists.
+    # Params:
+    # +resource+:: the resource (or key) string to be checked
+    def locked?(resource)
+      @servers.any? { |s| s.lock_exists?(resource)}
+    end
+
     private
 
     class RedisInstance
@@ -134,6 +141,14 @@ module Redlock
         end
       rescue
         # Nothing to do, unlocking is just a best-effort attempt.
+      end
+
+      def lock_exists?(resource, value = nil)
+        if value
+          @redis.exists(resource) && @redis.get(resource) == value
+        else
+          @redis.exists(resource)
+        end
       end
 
       private

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -323,6 +323,26 @@ RSpec.describe Redlock::Client do
     end
   end
 
+  describe '#owner?' do
+    subject { lock_manager.owner?(lock_info) }
+
+    let(:value) { @another_lock_info[:value] }
+    let(:lock_info) { @another_lock_info.merge(value: value) }
+
+    before { @another_lock_info = lock_manager.lock(resource_key, ttl) }
+    after { lock_manager.unlock(@another_lock_info) }
+
+    context 'when lock is not owned' do
+      let(:value) { 'invalid hex' }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when lock is owned' do
+      it { is_expected.to eq true }
+    end
+  end
+
   describe '#default_time_source' do
     context 'when CLOCK_MONOTONIC is available (MRI, JRuby)' do
       it 'returns a callable using Process.clock_gettime()' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -308,6 +308,21 @@ RSpec.describe Redlock::Client do
     end
   end
 
+  describe '#locked?' do
+    subject { lock_manager.locked?(resource_key) }
+
+    context 'when lock is available' do
+      it { is_expected.to eq false }
+    end
+
+    context 'when lock is unavailable' do
+      before { @another_lock_info = lock_manager.lock(resource_key, ttl) }
+      after { lock_manager.unlock(@another_lock_info) }
+
+      it { is_expected.to eq true }
+    end
+  end
+
   describe '#default_time_source' do
     context 'when CLOCK_MONOTONIC is available (MRI, JRuby)' do
       it 'returns a callable using Process.clock_gettime()' do


### PR DESCRIPTION
This PR adds two methods to `Redlock::Client`

### `#locked?(resource)`

Returns true if any client holds, held or is trying to acquire a lock for the given resource.

### `#owner?(lock_info)`

Returns true if the value of the given `lock_info` value matches the value of the lock of the resource.

*Note: This solution was inspired by #71 and I've also added @stlewis as co-author for the `#locked?` method*