### PR TITLE
Catch all redis connection exceptions when acquiring a lock

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -124,7 +124,7 @@ module Redlock
         recover_from_script_flush do
           @redis.evalsha @lock_script_sha, keys: [resource], argv: [val, ttl, allow_new_lock]
         end
-      rescue Redis::CannotConnectError
+      rescue Redis::BaseConnectionError
         false
       end
 


### PR DESCRIPTION
As best I can tell, the intention behind RedisInstance#lock is to treat connection related issues to a specific server as a chance to return false when establishing a quorum.

At a high level of concurrency, the method was instead triggering a Redis::TimeoutError, which was getting raised to the caller instead of counting against the quorum.

I opted to just catch everything that inherits Redis::BaseConnectionError.