### PR TITLE
Explicitly callout durations as milliseconds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Or install it yourself as:
 
 ### Acquiring a lock
 
+NOTE: All expiration durations are in milliseconds.
 ```ruby
   # Locking
   lock_manager = Redlock::Client.new([ "redis://127.0.0.1:7777", "redis://127.0.0.1:7778", "redis://127.0.0.1:7779" ])


### PR DESCRIPTION
Hi!

I just had a very good 🤦‍♀ moment where I was incorrectly thinking the key expiration durations were in seconds. Once I dove further into the docs [for the lock instance method](https://www.rubydoc.info/gems/redlock/Redlock/Client#lock-instance_method) I realized they were in milliseconds. To help other's avoid making the same mistake I thought an update to the README might be helpful. Totally open to presenting the information in a different way on the README if you have other suggestions. Let me know your thoughts!

Thanks!
Molly 