### PR TITLE
Revert "Don't load scripts on client initialization"

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -118,6 +118,8 @@ module Redlock
         else
           @redis = Redis.new(connection)
         end
+
+        load_scripts
       end
 
       def lock(resource, val, ttl, allow_new_lock)


### PR DESCRIPTION
This reverts commit e8389ac9e88d11bf50ebb170ce27f1d9b43a7483.

Without this then the `@unlock_script_sha` and `@lock_script_sha` are `nil` which causes the `evalsha` to fail on the first usage. 

This is causing us to get a high error rate from Redis.