### PR TITLE
Add the resource key to a lock error info

### DIFF
--- a/lib/redlock.rb
+++ b/lib/redlock.rb
@@ -3,5 +3,9 @@ require 'redlock/version'
 module Redlock
   autoload :Client, 'redlock/client'
 
-  LockError = Class.new(StandardError)
+  class LockError < StandardError
+    def initialize(resource)
+      super "failed to acquire lock on '#{resource}'".freeze
+    end
+  end
 end

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -93,11 +93,11 @@ module Redlock
     # Locks a resource, executing the received block only after successfully acquiring the lock,
     # and returning its return value as a result.
     # See Redlock::Client#lock for parameters.
-    def lock!(*args)
+    def lock!(resource, *args)
       fail 'No block passed' unless block_given?
 
-      lock(*args) do |lock_info|
-        raise LockError, 'failed to acquire lock' unless lock_info
+      lock(resource, *args) do |lock_info|
+        raise LockError, resource unless lock_info
         return yield
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -316,7 +316,9 @@ RSpec.describe Redlock::Client do
       after { lock_manager.unlock(@another_lock_info) }
 
       it 'raises a LockError' do
-        expect { lock_manager.lock!(resource_key, ttl) {} }.to raise_error(Redlock::LockError)
+        expect { lock_manager.lock!(resource_key, ttl) {} }.to raise_error(
+          Redlock::LockError, "failed to acquire lock on '#{resource_key}'"
+        )
       end
 
       it 'does not execute the block' do


### PR DESCRIPTION
Useful to know which lock resource failed.