### PR TITLE
WIP: Turn testing_mode into class attribute.

### DIFF
--- a/lib/redlock/testing.rb
+++ b/lib/redlock/testing.rb
@@ -1,17 +1,27 @@
 module Redlock
   class Client
-    attr_writer :testing_mode
+    class << self
+      attr_accessor :testing_mode
+    end
+
+    def testing_mode=(mode)
+      warn 'DEPRECATION WARNING: Instance-level `testing_mode` has been removed, and this ' +
+        'setter will be removed in the future. Please set the testing mode on the `Redlock::Client` ' +
+        'instead, e.g. `Redlock::Client.testing_mode = :bypass`.'
+
+      self.class.testing_mode = mode
+    end
 
     alias_method :try_lock_instances_without_testing, :try_lock_instances
 
     def try_lock_instances(resource, ttl, options)
-      if @testing_mode == :bypass
+      if self.class.testing_mode == :bypass
         {
           validity: ttl,
           resource: resource,
           value: options[:extend] ? options[:extend].fetch(:value) : SecureRandom.uuid
         }
-      elsif @testing_mode == :fail
+      elsif self.class.testing_mode == :fail
         false
       else
         try_lock_instances_without_testing resource, ttl, options
@@ -21,14 +31,14 @@ module Redlock
     alias_method :unlock_without_testing, :unlock
 
     def unlock(lock_info)
-      unlock_without_testing lock_info unless @testing_mode == :bypass
+      unlock_without_testing lock_info unless self.class.testing_mode == :bypass
     end
 
     class RedisInstance
       alias_method :load_scripts_without_testing, :load_scripts
 
       def load_scripts
-        load_scripts_without_testing
+        load_scripts_without_testing unless Redlock::Client.testing_mode == :bypass
       rescue Redis::CommandError
         # FakeRedis doesn't have #script, but doesn't need it either.
         raise unless defined?(::FakeRedis)


### PR DESCRIPTION
This patch replaces `testing_mode` with a class attr on `Redlock::Client`, so it can be set before instantiation. The old `testing_mode=` setter on the instance delegates to the class and outputs a warning. Setting different testing modes per client instance is therefore broken, but I highly doubt anyone was using this.

It's not pretty, admittedly, but it should solve the issue that Redis is called in the initializer (which it should, IMO) before the user had the chance to set the `testing_mode`. 

@leandromoreira What do you think?

Fixes #83 