### PR TITLE
CI: update rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: ruby
+cache: bundler
+sudo: false
+
+rvm:
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
+  - ruby-head
+
+before_install:
+  - yes | gem update --system
+  - gem install bundler -v "~> 2.0"
+
+script: bundle exec rspec spec
+
+jobs:
+  allow_failures:
+    - rvm: ruby-head
+
 services:
     - redis-server
-rvm:
-  - 2.2.2
-  - 2.5.6
-  - 2.6.4
-script: bundle exec rspec spec
-sudo: false
-cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,4 +53,4 @@ DEPENDENCIES
   rspec (~> 3, >= 3.0.0)
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/