### PR TITLE
testing lib

### DIFF
--- a/lib/redlock/testing.rb
+++ b/lib/redlock/testing.rb
@@ -1,3 +1,5 @@
+require 'redlock'
+
 module Redlock
   class Client
     class << self


### PR DESCRIPTION
require relock gem so that this is wired up correctly in rspec files that only need to modify the testing_mode, eg.

```
require 'redlock/testing'

Redlock::Client.testing_mode = :bypass
```