### PR TITLE
Don't reload scripts if they're already available

### DIFF
--- a/lib/redlock.rb
+++ b/lib/redlock.rb
@@ -2,6 +2,7 @@ require 'redlock/version'
 
 module Redlock
   autoload :Client, 'redlock/client'
+  autoload :Scripts, 'redlock/scripts'
 
   class LockError < StandardError
     def initialize(resource)

--- a/lib/redlock/scripts.rb
+++ b/lib/redlock/scripts.rb
@@ -1,0 +1,34 @@
+require 'digest'
+
+module Redlock
+  module Scripts
+    UNLOCK_SCRIPT = <<-eos
+      if redis.call("get",KEYS[1]) == ARGV[1] then
+        return redis.call("del",KEYS[1])
+      else
+        return 0
+      end
+    eos
+
+    # thanks to https://github.com/sbertrang/redis-distlock/blob/master/lib/Redis/DistLock.pm
+    # also https://github.com/sbertrang/redis-distlock/issues/2 which proposes the value-checking
+    # and @maltoe for https://github.com/leandromoreira/redlock-rb/pull/20#discussion_r38903633
+    LOCK_SCRIPT = <<-eos
+      if (redis.call("exists", KEYS[1]) == 0 and ARGV[3] == "yes") or redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("set", KEYS[1], ARGV[1], "PX", ARGV[2])
+      end
+    eos
+
+    PTTL_SCRIPT = <<-eos
+      return { redis.call("get", KEYS[1]), redis.call("pttl", KEYS[1]) }
+    eos
+
+    # We do not want to load the scripts on every Redlock::Client initialization.
+    # Hence, we rely on Redis handing out SHA1 hashes of the cached scripts and
+    # pre-calculate them instead of loading the scripts unconditionally. If the scripts
+    # have not been cached on Redis, `recover_from_script_flush` has our backs.
+    UNLOCK_SCRIPT_SHA = Digest::SHA1.hexdigest(UNLOCK_SCRIPT)
+    LOCK_SCRIPT_SHA   = Digest::SHA1.hexdigest(LOCK_SCRIPT)
+    PTTL_SCRIPT_SHA   = Digest::SHA1.hexdigest(PTTL_SCRIPT)
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Redlock::Client do
       expect(resource_key).to_not be_lockable(lock_manager, ttl)
       lock_manager.unlock(lock_info)
     end
+
+    it 'does not load scripts' do
+      redis_client.script(:flush)
+
+      pool = ConnectionPool.new { Redis.new(url: "redis://#{redis1_host}:#{redis1_port}") }
+      redlock = Redlock::Client.new([pool])
+
+      expect(redis_client.info["number_of_cached_scripts"]).to eq(nil)
+    end
   end
 
   describe 'lock' do


### PR DESCRIPTION
When initializing the Redlock client it always inserts scripts into Redis. The issue with that is if Redlock is used in a short-lived process, such as a job, then it could potentially be initialized many times causing the scripts to be inserted into Redis every time even if they're already present.

This PR changes when the scripts are loaded. Instead of always loading on initialize, it generates the SHA1 hash to be sent to Redis and only if it doesn't exist then it will load the scripts into Redis before retrying.

The retry behaviour already exists so if a script SHA is sent to Redis and it doesn't exist then it is rescued and the scripts are loaded.