### PR TITLE
gemspec: Remove unused "executables" directive

### DIFF
--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'BSD-2-Clause'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
This gem exposes no executables, so we can remove the configuration.