### PR TITLE
README: Drop the defunct Inch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Code Climate](https://codeclimate.com/github/leandromoreira/redlock-rb/badges/gpa.svg)](https://codeclimate.com/github/leandromoreira/redlock-rb)
 [![Gem Version](https://badge.fury.io/rb/redlock.svg)](http://badge.fury.io/rb/redlock)
 [![security](https://hakiri.io/github/leandromoreira/redlock-rb/master.svg)](https://hakiri.io/github/leandromoreira/redlock-rb/master)
-[![Inline docs](http://inch-ci.org/github/leandromoreira/redlock-rb.svg?branch=master)](http://inch-ci.org/github/leandromoreira/redlock-rb)
-
 
 # Redlock - A ruby distributed lock using redis.
 


### PR DESCRIPTION
The service seems non-operational.