### PR TITLE
Re-raise Redis connection errors in `#lock`

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -170,8 +170,6 @@ module Redlock
         recover_from_script_flush do
           @redis.with { |conn| conn.evalsha Scripts::LOCK_SCRIPT_SHA, keys: [resource], argv: [val, ttl, allow_new_lock] }
         end
-      rescue Redis::BaseConnectionError
-        false
       end
 
       def unlock(resource, val)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -242,14 +242,14 @@ RSpec.describe Redlock::Client do
     end
 
     context 'when a server goes away' do
-      it 'does not raise an error on connection issues' do
-        # We re-route the lock manager to a (hopefully) non-existent Redis URL.
+      it 'raises an error on connection issues' do
+        # Set lock manager to a (hopefully) non-existent Redis URL to test error
         redis_instance = lock_manager.instance_variable_get(:@servers).first
         redis_instance.instance_variable_set(:@redis, unreachable_redis)
 
         expect {
-          expect(lock_manager.lock(resource_key, ttl)).to be_falsey
-        }.to_not raise_error
+          lock_manager.lock(resource_key, ttl)
+        }.to raise_error(Redis::CannotConnectError)
       end
     end
 
@@ -259,7 +259,9 @@ RSpec.describe Redlock::Client do
         redis_instance = lock_manager.instance_variable_get(:@servers).first
         old_redis = redis_instance.instance_variable_get(:@redis)
         redis_instance.instance_variable_set(:@redis, unreachable_redis)
-        expect(lock_manager.lock(resource_key, ttl)).to be_falsey
+        expect {
+          lock_manager.lock(resource_key, ttl)
+        }.to raise_error(Redis::CannotConnectError)
         redis_instance.instance_variable_set(:@redis, old_redis)
         expect(lock_manager.lock(resource_key, ttl)).to be_truthy
       end


### PR DESCRIPTION
This is a fix for [the example I presented in a prior issue](https://github.com/leandromoreira/redlock-rb/issues/108#issuecomment-1130698697).

Currently, `#lock` returns `false` when a lock cannot be acquired, whether due to a lock already being present on the key, or a connection issue. This PR stops swallowing Redis connection errors, since they are different from the key already being locked. The Redlock user can determine how to correctly handle these errors.

I updated the existing tests for the new logic. I didn't see anything in the documentation referencing the existing behavior, so didn't make any documentation changes.

Please note that this change may violate expectations for others using the library if they rely on the previous "return false on connection error" logic. I could imagine that someone would not be wrapping their logic in a `rescue`, so it would fail in a previously unexpected manner. I think the maintainers may want to consider whether this is a breaking change that would need a bigger semver change.

Also, thanks for maintaining this project! It has been helpful in preventing the race condition that I outlined in the issue (at least a handful of times in the last week.)