### PR TITLE
Updates dependencies and Gemfile.lock to use latest redis version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     redlock (1.2.2)
-      redis (>= 3.0.0, < 5.0)
+      redis (>= 3.0.0, < 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,24 +14,27 @@ GEM
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     docile (1.4.0)
     json (2.3.1)
     rake (13.0.6)
-    redis (4.4.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    redis (5.0.1)
+      redis-client (~> 0.7)
+    redis-client (0.7.1)
+      connection_pool
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -40,8 +43,8 @@ GEM
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (1.1.0)
-    tins (1.29.1)
+    thor (1.2.1)
+    tins (1.31.1)
       sync
 
 PLATFORMS
@@ -56,4 +59,4 @@ DEPENDENCIES
   rspec (~> 3, >= 3.0.0)
 
 BUNDLED WITH
-   2.2.22
+   2.3.7

--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'redis', '>= 3.0.0', '< 5.0'
+  spec.add_dependency 'redis', '>= 3.0.0', '< 6.0'
 
   spec.add_development_dependency 'connection_pool', '~> 2.2'
   spec.add_development_dependency 'coveralls', '~> 0.8'


### PR DESCRIPTION
* Fixes https://github.com/leandromoreira/redlock-rb/issues/114
* Loosens the runtime dependencies to support the latest redis version.
* All existing specs pass. 