### PR TITLE
Use positional arguments for `conn.evalsha`

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -168,7 +168,7 @@ module Redlock
 
       def lock(resource, val, ttl, allow_new_lock)
         recover_from_script_flush do
-          @redis.with { |conn| conn.evalsha Scripts::LOCK_SCRIPT_SHA, keys: [resource], argv: [val, ttl, allow_new_lock] }
+          @redis.with { |conn| conn.evalsha Scripts::LOCK_SCRIPT_SHA, [resource], [val, ttl, allow_new_lock] }
         end
       rescue Redis::BaseConnectionError
         false
@@ -176,7 +176,7 @@ module Redlock
 
       def unlock(resource, val)
         recover_from_script_flush do
-          @redis.with { |conn| conn.evalsha Scripts::UNLOCK_SCRIPT_SHA, keys: [resource], argv: [val] }
+          @redis.with { |conn| conn.evalsha Scripts::UNLOCK_SCRIPT_SHA, [resource], [val] }
         end
       rescue
         # Nothing to do, unlocking is just a best-effort attempt.


### PR DESCRIPTION
In my manual testing this appears to lock correctly with both `redis-rb` `4.8.0` and `5.0.5`

Fixes #114