### PR TITLE
fix: always treat redis instance as pool-like

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -168,13 +168,17 @@ module Redlock
 
       def lock(resource, val, ttl, allow_new_lock)
         recover_from_script_flush do
-          @redis.call('EVALSHA', Scripts::LOCK_SCRIPT_SHA, 1, resource, val, ttl, allow_new_lock)
+          @redis.with { |conn|
+            conn.call('EVALSHA', Scripts::LOCK_SCRIPT_SHA, 1, resource, val, ttl, allow_new_lock)
+          }
         end
       end
 
       def unlock(resource, val)
         recover_from_script_flush do
-          @redis.call('EVALSHA', Scripts::UNLOCK_SCRIPT_SHA, 1, resource, val)
+          @redis.with { |conn|
+            conn.call('EVALSHA', Scripts::UNLOCK_SCRIPT_SHA, 1, resource, val)
+          }
         end
       rescue
         # Nothing to do, unlocking is just a best-effort attempt.
@@ -182,7 +186,9 @@ module Redlock
 
       def get_remaining_ttl(resource)
         recover_from_script_flush do
-          @redis.call('EVALSHA', Scripts::PTTL_SCRIPT_SHA, 1, resource)
+          @redis.with { |conn|
+            conn.call('EVALSHA', Scripts::PTTL_SCRIPT_SHA, 1, resource)
+          }
         end
       rescue RedisClient::ConnectionError
         nil

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Redlock::Client do
   describe '(testing mode)' do
     describe 'try_lock_instances' do
       context 'when testing with bypass mode' do
-        before { lock_manager.testing_mode = :bypass }
+        before { Redlock::Client.testing_mode = :bypass }
 
         it 'bypasses the redis servers' do
           expect(lock_manager).to_not receive(:try_lock_instances_without_testing)
@@ -22,7 +22,7 @@ RSpec.describe Redlock::Client do
       end
 
       context 'when testing with fail mode' do
-        before { lock_manager.testing_mode = :fail }
+        before { Redlock::Client.testing_mode = :fail }
 
         it 'fails' do
           expect(lock_manager).to_not receive(:try_lock_instances_without_testing)
@@ -33,7 +33,7 @@ RSpec.describe Redlock::Client do
       end
 
       context 'when testing is disabled' do
-        before { lock_manager.testing_mode = nil }
+        before { Redlock::Client.testing_mode = nil }
 
         it 'works as usual' do
           expect(lock_manager).to receive(:try_lock_instances_without_testing)


### PR DESCRIPTION
since #122 https://github.com/leandromoreira/redlock-rb/pull/122/files#r1104937276