### PR TITLE
Add support for passing config objects to the client

### DIFF
--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'redis-client', '~> 0.14.1'
+  spec.add_dependency 'redis-client', '>= 0.14.1', '< 1.0.0'
 
   spec.add_development_dependency 'connection_pool', '~> 2.2'
   spec.add_development_dependency 'coveralls', '~> 0.8'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Redlock::Client do
       lock_manager.unlock(lock_info)
     end
 
+    it 'accepts Configuration hashes' do
+      config = { url: "redis://#{redis1_host}:#{redis1_port}" }
+      _redlock = Redlock::Client.new([config])
+
+      lock_info = lock_manager.lock(resource_key, ttl)
+      expect(lock_info).to be_a(Hash)
+      expect(resource_key).to_not be_lockable(lock_manager, ttl)
+      lock_manager.unlock(lock_info)
+    end
+
     it 'does not load scripts' do
       redis_client.call('SCRIPT', 'FLUSH')
 


### PR DESCRIPTION
With the migration to `RedisClient` instead of `Redis` the support for passing redis configurations was broken. 

This PR adds the support back. 