### PR TITLE
Include the error messages when we fail due to too many errors.

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -319,7 +319,8 @@ module Redlock
         @servers.each { |s| s.unlock(resource, value) }
 
         if errors.size >= @quorum
-          raise LockAcquisitionError.new('Too many Redis errors prevented lock acquisition', errors)
+          err_msgs = errors.map { |e| "#{e.class}: #{e.message}" }.join("\n")
+          raise LockAcquisitionError.new("Too many Redis errors prevented lock acquisition:\n#{err_msgs}", errors)
         end
 
         false


### PR DESCRIPTION
I found the `"Too many Redis errors prevented lock acquisition"` to be a little unhelpful. If we'd see this in an error tracking system, we'd still have to guess what the errors were.

The error object does come with an array containing all the original errors but I thought it'd make things a lot easier if we'd also include them in the error message. Otherwise I'd end up having to rescue the `LockAcquisitionError` on every call just to inspect and report the original errors.

With this change we can just call the `lock` method as is and error tracking systems will get a helpful message telling us exactly what happened.