### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/leandromoreira/redlock-rb'
   spec.license       = 'BSD-2-Clause'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").grep_v(%r{^spec/})
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 18944 bytes
after:  14848 bytes
```