### PR TITLE
Yield lock_info to #lock! block, like #lock does

### DIFF
--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -113,7 +113,7 @@ module Redlock
 
       lock(resource, *args) do |lock_info|
         raise LockError, resource unless lock_info
-        return yield
+        return yield lock_info
       end
     end
 


### PR DESCRIPTION
`#lock` method [yields the lock_info](https://github.com/leandromoreira/redlock-rb/blob/f176e5748a41e8b35a9a986fb6cc8eeae203a64f/lib/redlock/client.rb#L91) object to the block.

But `#lock!` method does not.

This PR changes this. By passing `lock_info` to the block, the block is able to extend the lock.

What do you think about this?