### PR TITLE
Fix #148 Add Redis::CommandError handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in redlock_rb.gemspec
 gemspec
+
+# deprecated, but included temporarily to unblock Ruby test matrix
+gem 'ostruct'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in redlock_rb.gemspec
 gemspec
-
-# deprecated, but included temporarily to unblock Ruby test matrix
-gem 'ostruct'

--- a/lib/redlock/client.rb
+++ b/lib/redlock/client.rb
@@ -244,11 +244,25 @@ module Redlock
         end
       end
 
+      # Exception classes that may be raised for NOSCRIPT errors.
+      # RedisClient::CommandError is raised when using redis-client directly.
+      # Redis::CommandError (or its subclass Redis::NoScriptError) is raised
+      # when using the redis gem wrapper.
+      # See: https://github.com/leandromoreira/redlock-rb/issues/124
+      # See: https://github.com/leandromoreira/redlock-rb/issues/148
+      def script_error_classes
+        @script_error_classes ||= begin
+          classes = [RedisClient::CommandError]
+          classes << Redis::CommandError if defined?(Redis::CommandError)
+          classes
+        end
+      end
+
       def recover_from_script_flush
         retry_on_noscript = true
         begin
           yield
-        rescue RedisClient::CommandError => e
+        rescue *script_error_classes => e
           # When somebody has flushed the Redis instance's script cache, we might
           # want to reload our scripts. Only attempt this once, though, to avoid
           # going into an infinite loop.

--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'connection_pool', '~> 2.2'
   spec.add_development_dependency 'coveralls_reborn', '~> 0.29'
-  spec.add_development_dependency 'json', '>= 2.3.0', '~> 2.3.1'
+  spec.add_development_dependency 'json', '>= 2.3.0'
   spec.add_development_dependency 'rake', '>= 11.1.2', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3', '>= 3.0.0'
 end

--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis-client', '>= 0.14.1', '< 1.0.0'
 
   spec.add_development_dependency 'connection_pool', '~> 2.2'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.29'
   spec.add_development_dependency 'json', '>= 2.3.0', '~> 2.3.1'
   spec.add_development_dependency 'rake', '>= 11.1.2', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3', '>= 3.0.0'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -108,17 +108,13 @@ RSpec.describe Redlock::Client do
         it 'fails to acquire a lock if majority of Redis instances are not available' do
           redlock = Redlock::Client.new(servers_without_quorum)
 
-          expected_msg = <<~MSG
-            failed to acquire lock on 'Too many Redis errors prevented lock acquisition:
-            RedisClient::CannotConnectError: Connection refused - connect(2) for 127.0.0.1:46864
-            RedisClient::CannotConnectError: Connection refused - connect(2) for 127.0.0.1:46864'
-          MSG
-
           expect {
             redlock.lock(resource_key, ttl)
           }.to raise_error do |error|
             expect(error).to be_a(Redlock::LockAcquisitionError)
-            expect(error.message).to eq(expected_msg.chomp)
+            expect(error.message).to include('Too many Redis errors prevented lock acquisition')
+            expect(error.message).to include('RedisClient::CannotConnectError')
+            expect(error.message).to include('Connection refused')
             expect(error.errors.size).to eq(2)
           end
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -381,6 +381,108 @@ RSpec.describe Redlock::Client do
       end
     end
 
+    context 'when using the redis gem (Redis::CommandError)' do
+      # The redis gem raises Redis::CommandError (or Redis::NoScriptError) instead of
+      # RedisClient::CommandError. This tests that both error hierarchies are handled.
+      # See: https://github.com/leandromoreira/redlock-rb/issues/124
+      # See: https://github.com/leandromoreira/redlock-rb/issues/148
+
+      before(:all) do
+        # Define Redis::CommandError if not already defined (simulates redis gem being loaded)
+        unless defined?(Redis::CommandError)
+          module Redis
+            class CommandError < StandardError; end
+          end
+          @redis_command_error_defined_by_test = true
+        end
+      end
+
+      after(:all) do
+        # Clean up the mock class if we defined it
+        if @redis_command_error_defined_by_test
+          Redis.send(:remove_const, :CommandError)
+          Object.send(:remove_const, :Redis) if Redis.constants.empty?
+        end
+      end
+
+      describe '#script_error_classes' do
+        it 'includes RedisClient::CommandError' do
+          redis_instance = lock_manager.instance_variable_get(:@servers).first
+          expect(redis_instance.send(:script_error_classes)).to include(RedisClient::CommandError)
+        end
+
+        it 'includes Redis::CommandError when defined' do
+          redis_instance = lock_manager.instance_variable_get(:@servers).first
+          # Clear memoization to pick up the newly defined class
+          redis_instance.instance_variable_set(:@script_error_classes, nil)
+          expect(redis_instance.send(:script_error_classes)).to include(Redis::CommandError)
+        end
+      end
+
+      context 'when Redis::CommandError NOSCRIPT is raised' do
+        it 'recovers by reloading scripts' do
+          redis_instance = lock_manager.instance_variable_get(:@servers).first
+          # Clear memoization to ensure Redis::CommandError is included
+          redis_instance.instance_variable_set(:@script_error_classes, nil)
+
+          call_count = 0
+          allow(redis_instance).to receive(:synchronize).and_wrap_original do |original_method, &block|
+            call_count += 1
+            if call_count == 1
+              # First call raises Redis::CommandError with NOSCRIPT
+              raise Redis::CommandError, 'NOSCRIPT No matching script'
+            else
+              original_method.call(&block)
+            end
+          end
+
+          expect(redis_instance).to receive(:load_scripts).and_call_original
+
+          # Should recover and successfully lock
+          lock_info = lock_manager.lock(resource_key, ttl)
+          expect(lock_info).to be_truthy
+          lock_manager.unlock(lock_info) if lock_info
+        end
+
+        it 'does not retry more than once per operation' do
+          redis_instance = lock_manager.instance_variable_get(:@servers).first
+          redis_instance.instance_variable_set(:@script_error_classes, nil)
+
+          # Always raise Redis::CommandError NOSCRIPT
+          allow(redis_instance).to receive(:synchronize).and_raise(
+            Redis::CommandError, 'NOSCRIPT No matching script'
+          )
+
+          load_scripts_count = 0
+          allow(redis_instance).to receive(:load_scripts) { load_scripts_count += 1 }
+
+          expect {
+            lock_manager.lock(resource_key, ttl)
+          }.to raise_error(Redlock::LockAcquisitionError)
+
+          # Should have called load_scripts once per retry attempt (8 times total:
+          # lock + unlock for each of retry_count+1 attempts, but unlock swallows errors)
+          expect(load_scripts_count).to eq(8)
+        end
+
+        it 're-raises non-NOSCRIPT Redis::CommandError' do
+          redis_instance = lock_manager.instance_variable_get(:@servers).first
+          redis_instance.instance_variable_set(:@script_error_classes, nil)
+
+          allow(redis_instance).to receive(:synchronize).and_raise(
+            Redis::CommandError, 'ERR some other error'
+          )
+
+          expect {
+            lock_manager.lock(resource_key, ttl)
+          }.to raise_error(Redlock::LockAcquisitionError) do |e|
+            expect(e.errors[0]).to be_a(Redis::CommandError)
+            expect(e.errors[0].message).to eq('ERR some other error')
+          end
+        end
+      end
+    end
+
     describe 'block syntax' do
       context 'when lock is available' do
         it 'locks' do


### PR DESCRIPTION
Redlock 2.0+ mostly supports object instantiation, except for this edge case. 

See: 
* https://github.com/leandromoreira/redlock-rb/issues/148
* https://github.com/leandromoreira/redlock-rb/issues/124

Aside from causing difficulties while upgrading, this limits the use of certain functionality. 

I tried to be careful in error handling here that the error class is defined and loaded. This is an extension of the solution offered here:
* https://github.com/leandromoreira/redlock-rb/issues/148#issuecomment-1864310235

Added a spec context for good measure.