### PR TITLE
Fix link to Redis distributed lock documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > There are a number of libraries and blog posts describing how to implement a DLM (Distributed Lock Manager) with Redis, but every library uses a different approach, and many use a simple approach with lower guarantees compared to what can be achieved with slightly more complex designs.
 
-This is an implementation of a proposed [distributed lock algorithm with Redis](http://redis.io/topics/distlock). It started as a fork from [antirez implementation.](https://github.com/antirez/redlock-rb)
+This is an implementation of a proposed [distributed lock algorithm with Redis](https://web.archive.org/web/20220305095503/https://redis.io/topics/distlock). It started as a fork from [antirez implementation.](https://github.com/antirez/redlock-rb)
 
 ## Compatibility
 


### PR DESCRIPTION
The current link redirects to a generic redis page these days, so i linked to a wayback machine link where i found it