### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/redlock.gemspec
+++ b/redlock.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |spec|
   spec.license               = 'BSD-2-Clause'
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = `git ls-files lib -z`.split("\x0") + ['CHANGELOG.md', 'LICENSE', 'README.md']
   spec.require_paths = ['lib']
 
   spec.add_dependency 'redis-client', '>= 0.14.1', '< 1.0.0'


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 20K	before.tar
 16K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 20K   | 16K   | −4K (⏷ −20%)     |


###  whitch files was deleted?

```diff
data
-├── .github
-│   └── workflows
-│       └── ci.yml
 ├── lib
 │   ├── redlock
 │   │   ├── client.rb
 │   │   ├── scripts.rb
 │   │   ├── testing.rb
 │   │   └── version.rb
 │   └── redlock.rb
-├── spec
-│   ├── client_spec.rb
-│   ├── spec_helper.rb
-│   └── testing_spec.rb
-├── .gitignore
-├── .rspec
 ├── CHANGELOG.md
-├── clean_docker.sh
-├── CONTRIBUTORS
-├── docker-compose.yml
-├── Gemfile
 ├── LICENSE
-├── Makefile
-├── Rakefile
 ├── README.md
-└── redlock.gemspec
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)